### PR TITLE
Add support for color template var in highlight template

### DIFF
--- a/src/util/upsertRaindropPage.ts
+++ b/src/util/upsertRaindropPage.ts
@@ -105,7 +105,8 @@ const ioCreateAnnotationBlock = async (
 ): Promise<BlockEntity> => {
   const highlightFormatted = settings.formatting_template
     .highlight()
-    .replace("{text}", annotation.text);
+    .replace("{text}", annotation.text)
+    .replace("{color}", annotation.color);
   const noteFormatted = settings.formatting_template
     .annotation()
     .replace("{text}", annotation.note);


### PR DESCRIPTION
Thank you for the plugin. 

I noticed that the `{color}`-variable in the highlight template does not get replaced by the actual color value as described in the template description:
https://github.com/phildenhoff/logseq-raindrop/blob/9fc490613bc5927f17a9a7a67ad00c3004988753/src/util/settings.ts#L23
Instead the string "{color}" is printed as is. I investigated the issue real quick and saw that there was no code that supports the functionality.

I created a quick PR in case you want to add support as specified in the description (after looking at the code, I felt that it actually might make more sense to add it as a block-property next to `annotation-id`). So if it was just the description that was erroneous feel free to close the PR.