### PR TITLE
Import more than three highlights per raindrop

### DIFF
--- a/src/util/raindropTransformer.ts
+++ b/src/util/raindropTransformer.ts
@@ -70,10 +70,7 @@ type RaindropResponse = {
 };
 
 // below are normalized values
-export const raindropTransformer = (
-  r: RaindropResponse,
-  collections: Collection[]
-): Raindrop => {
+export const raindropTransformer = (r: RaindropResponse): Raindrop => {
   const annotations = r.highlights.map(
     (item): Annotation => ({
       note: item.note,


### PR DESCRIPTION
The plugins loads all the highlights that are supposed to be loaded via
the multiple endpoint (ref: https://developer.raindrop.io/v1/raindrops/multiple).
While the documentation is silent about it the response seems to return
a maximum of three highlights per raindrop. This conforms to the number
of highlights shown as preview within the raindrop app.

This adds a call to the endpoint for selecting a single raindrop (ref: https://developer.raindrop.io/v1/raindrops/single)
which again is the same as what the raindrop app itself does to display
all highlights in the footer of a loaded raindrop.

Fix #9