### PR TITLE
Always create first block when creating a new page

### DIFF
--- a/src/util/upsertRaindropPage.ts
+++ b/src/util/upsertRaindropPage.ts
@@ -81,7 +81,7 @@ const ioCreateOrLoadPage = async (r: Raindrop) => {
     await logseq.Editor.createPage(
       logseqRaindropPrefix + r.title,
       {},
-      { createFirstBlock: false, redirect: true }
+      { createFirstBlock: true, redirect: true }
     );
   }
   const propBlock = (await logseq.Editor.getCurrentPageBlocksTree()).at(0);


### PR DESCRIPTION
This PR aimes to fix the issues other people reported in https://github.com/phildenhoff/logseq-raindrop/issues/25.
I've also experience the same, and I could reproduce the issue both on a windows and mac, with fresh installs. 

The weird thing is that the issue happens with _almost_ all the links for me, but a few here and there seem to just work.
For example this link doesn't work: https://www.quantamagazine.org/physics-experiments-spell-doom-for-quantum-collapse-theory-20221020
But this one does https://www.quantamagazine.org/human-brains-are-hard-to-study-sergiu-pasca-grows-useful-substitutes-20221012.

I've looked at the Raindrop API output and I can't see anything different about the responses.

The logs:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'uuid')
    at index.72455903.js:13:704
    at Array.map (<anonymous>)
    at Kn (index.72455903.js:13:250)
    at pi (index.72455903.js:13:627)
    at vi (index.72455903.js:13:2117)
    at async Oi (index.72455903.js:15:757)
```

I've stepped through the code and it seems like sometimes there's a race condition and the block at the top of the page that contains the page properties doesn't exist when the plugin is trying to insert the metadata.

Either way, this PR fixes it by always creating the first block. As far as I can tell there's no detrimental side-effect to this change. I've been using it this way for a few days and it just works 🥳 