### PR TITLE
Support disabling adding empty page annotation

### DIFF
--- a/src/services/logseq/emptyState.spec.ts
+++ b/src/services/logseq/emptyState.spec.ts
@@ -6,7 +6,11 @@ import { ioAddEmptyStateBlock, ioRemoveEmptyStateBlock } from "./emptyState.js";
 
 describe("ioAddEmptyStateBlock", () => {
   it("should add a new block to let the user know that there are no annotations", async () => {
-    const mockLogseqClient = generateMoqseqClient();
+    const mockLogseqClient = generateMoqseqClient({
+      settings: {
+        enable_empty_page_state: true,
+      },
+    });
     const page = await mockLogseqClient.createPage("test");
     assert(page);
     const pageBlocksBefore = await mockLogseqClient.getBlockTreeForPage(
@@ -25,7 +29,11 @@ describe("ioAddEmptyStateBlock", () => {
   });
 
   it("must only add the block once", async () => {
-    const mockLogseqClient = generateMoqseqClient();
+    const mockLogseqClient = generateMoqseqClient({
+      settings: {
+        enable_empty_page_state: true,
+      },
+    });
     const page = await mockLogseqClient.createPage("test");
     assert(page);
     const pageBlocksBefore = await mockLogseqClient.getBlockTreeForPage(
@@ -44,11 +52,33 @@ describe("ioAddEmptyStateBlock", () => {
     expect(actualSecond).toBeTruthy();
     expect(actualSecond.length).toBe(1);
   });
+
+  it("must not add a block when `enable_empty_page_state` is disabled", async () => {
+    const mockLogseqClient = generateMoqseqClient({
+      settings: {
+        enable_empty_page_state: false,
+      },
+    });
+    const page = await mockLogseqClient.createPage("test");
+    assert(page);
+    const pageBlocksBefore = await mockLogseqClient.getBlockTreeForPage(
+      page.uuid
+    );
+    await ioAddEmptyStateBlock(pageBlocksBefore, page.uuid, mockLogseqClient);
+
+    const actual = await mockLogseqClient.getBlockTreeForPage(page.uuid);
+    expect(actual).toBeTruthy();
+    expect(actual.length).toBe(0);
+  });
 });
 
 describe("ioRemoveEmptyStateBlock", () => {
   it("must remove the block", async () => {
-    const mockLogseqClient = generateMoqseqClient();
+    const mockLogseqClient = generateMoqseqClient({
+      settings: {
+        enable_empty_page_state: true,
+      },
+    });
     const page = await mockLogseqClient.createPage("test");
     assert(page);
 
@@ -76,7 +106,11 @@ describe("ioRemoveEmptyStateBlock", () => {
   });
 
   it("must not remove any other blocks", async () => {
-    const mockLogseqClient = generateMoqseqClient();
+    const mockLogseqClient = generateMoqseqClient({
+      settings: {
+        enable_empty_page_state: true,
+      },
+    });
     const page = await mockLogseqClient.createPage("test");
     assert(page);
 

--- a/src/services/logseq/emptyState.ts
+++ b/src/services/logseq/emptyState.ts
@@ -22,6 +22,8 @@ export const ioAddEmptyStateBlock = async (
   pageUuid: string,
   logseqClient: LogseqServiceClient
 ) => {
+  if (!(await logseqClient.settings.get("enable_empty_page_state"))) return;
+
   const blocksWithProperties = filterBlocksWithPropertyField(pageBlocks);
   const pageHasBlockWithNoAnnotationProp = await someBlockHasProperty(
     blocksWithProperties,

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -57,6 +57,16 @@ const settingsConfig: SettingSchemaDesc[] = [
     key: "broken_experimental_features",
     type: "boolean",
   },
+  {
+    type: "boolean",
+    key: "enable_empty_page_state",
+    title: "Enable empty page state",
+    default: true,
+    description:
+      "When a Raindrop page is imported, but has no annotations, a block will be added to the page letting you know that the page is empty (and that nothing went wrong)." +
+      "\n\n" +
+      "If you disable this, no blocks will be added but **you will have to delete existing blocks manually**.",
+  },
 ];
 
 /**


### PR DESCRIPTION
You can now disable the empty page block when you've imported a Raindrop but have no annotations.

To update this setting, click the Plugins icon, then Settings, then Raindrop.

![image](https://github.com/phildenhoff/logseq-raindrop/assets/17505728/750ce4c7-926e-45f9-8047-05c1e81f9785)
