### PR TITLE
First crack at single-page imports

### DIFF
--- a/src/components/organisms/ImportRaindrops.svelte
+++ b/src/components/organisms/ImportRaindrops.svelte
@@ -12,6 +12,8 @@
   import { logseqClientCtxKey } from "src/services/logseq/client.js";
   import { getRaindrop, searchTerm } from "@services/raindrop/index.js";
 
+  import PageImport from "./PageImport.svelte";
+
   const remoteData = writable<TRaindrop[]>([]);
   const requestsInFlight = writable(0);
   const mostRecentRequestTime = writable(new Date(0));
@@ -58,6 +60,8 @@
     performSearch("");
   });
 </script>
+
+<PageImport />
 
 <div>
   <h3>Import specific page</h3>

--- a/src/components/organisms/PageImport.svelte
+++ b/src/components/organisms/PageImport.svelte
@@ -17,6 +17,10 @@
     userPreferences,
     ($userPrefences) => $userPrefences.broken_experimental_features
   );
+  const hasEnabledSinglePageImports = derived(
+    userPreferences,
+    ($userPrefences) => $userPrefences.sync_to_single_page
+  );
 
   const remoteData = writable<TRaindrop[]>([]);
   const requestsInFlight = writable(0);
@@ -67,7 +71,7 @@
   }
 </script>
 
-{#if $hasEnabledExperimentalFeatures}
+{#if $hasEnabledExperimentalFeatures && $hasEnabledSinglePageImports}
 <div class="experimental">
   <h3>Import Recently Added</h3>
   <p>Bookmarks new to your Raindrop. This does not include old bookmarks that you've recently updated by adding new tags or annotations.</p>

--- a/src/components/organisms/PageImport.svelte
+++ b/src/components/organisms/PageImport.svelte
@@ -6,6 +6,7 @@
   import { raindropTransformer } from "@util/raindropTransformer.js";
   import Raindrop from "@atoms/Raindrop.svelte";
   import { userPreferences } from "src/stores/userPreferences.js";
+  import { formatSecondsAsDateTime } from "@util/time.js";
 
   const lastSyncTimestampSecs = derived(
     userPreferences,
@@ -16,16 +17,6 @@
     userPreferences,
     ($userPrefences) => $userPrefences.broken_experimental_features
   );
-
-  const secondsToMs = (value: number) => value * 1000;
-  const formatterOptions = {
-    year: "numeric",
-    month: "numeric",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-  } as const;
-  const formatSecondsAsDateTime = (seconds: number) => Intl.DateTimeFormat(undefined, formatterOptions).format(secondsToMs(seconds));
 
   const remoteData = writable<TRaindrop[]>([]);
   const requestsInFlight = writable(0);
@@ -41,7 +32,6 @@
       return $remoteData2.filter((raindrop) => raindrop.created > lastSyncDate);
     }
   )
-
 
   const performSearch = async (): Promise<void> => {
     const requestTime = new Date();

--- a/src/components/organisms/PageImport.svelte
+++ b/src/components/organisms/PageImport.svelte
@@ -11,7 +11,7 @@
     userPreferences,
     ($userPrefences) => Number($userPrefences.last_sync_timestamp) || 0
   );
-  let lastSyncTimestampValueStr = writable($lastSyncTimestampSecs);
+  let lastSyncTimestampValueStr = writable($lastSyncTimestampSecs.toString() || '0');
   const hasEnabledExperimentalFeatures = derived(
     userPreferences,
     ($userPrefences) => $userPrefences.broken_experimental_features
@@ -74,9 +74,6 @@
     userPreferences.updateSetting('last_sync_timestamp', Number(newValue));
   }
 </script>
-
-{hasEnabledExperimentalFeatures}
-{$hasEnabledExperimentalFeatures}
 
 {#if $hasEnabledExperimentalFeatures}
 <div class="experimental">

--- a/src/components/organisms/PageImport.svelte
+++ b/src/components/organisms/PageImport.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { settings } from "@util/settings.js";
+  import { derived, writable } from "svelte/store";
+
+  let lastSyncDatetime = writable(0);
+
+  const hasEnabledExperimentalFeatures = settings.enable_broken_experimental_features(); 
+
+  const msToSeconds = (value: number) => value * 1000;
+  const formatterOptions = {
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+  } as const;
+  const formatMsAsDateTime = (value: number) => Intl.DateTimeFormat(undefined, formatterOptions).format(msToSeconds(value));
+</script>
+
+{#if hasEnabledExperimentalFeatures}
+<div class="experimental">
+  <h3>Import Recently Added</h3>
+  <p>Bookmarks new to your Raindrop. This does not include old bookmarks that you've recently updated by adding new tags or annotations.</p>
+  <button>Fetch new bookmarks</button>
+  <form class="sync-container">
+    <label for="last-sync">Last sync: {formatMsAsDateTime($lastSyncDatetime)}</label>
+    <input id="last-sync" type="text" bind:value={$lastSyncDatetime}/>
+  </form>
+</div>
+{/if}
+
+<style>
+  .experimental {
+    background-color: #411100;
+    padding: 8px;
+  }
+
+  h3 {
+    margin-top: 0;
+  }
+
+  .sync-container {
+    display: flex;
+    flex-direction: column;
+    max-width: 24ch;
+  }
+
+  @media (prefers-color-scheme: light) {
+    .experimental {
+      background-color: #f4c8b8;
+    }
+  }
+</style>

--- a/src/components/organisms/PageImport.svelte
+++ b/src/components/organisms/PageImport.svelte
@@ -1,12 +1,20 @@
 <script lang="ts">
-  import { settings } from "@util/settings.js";
   import { derived, writable } from "svelte/store";
 
-  let lastSyncDatetime = writable(0);
+  import type {Raindrop as TRaindrop} from "@types";
+  import { settings } from "@util/settings.js";
+  import { raindropTransformer } from "@util/raindropTransformer.js";
+  import Raindrop from "@atoms/Raindrop.svelte";
+
+  let lastSyncTimestampValueStr = writable('0');
+  const lastSyncTimestampSecs = derived(
+    lastSyncTimestampValueStr,
+    ($value) => Number($value) || 0
+  );
 
   const hasEnabledExperimentalFeatures = settings.enable_broken_experimental_features(); 
 
-  const msToSeconds = (value: number) => value * 1000;
+  const secondsToMs = (value: number) => value * 1000;
   const formatterOptions = {
     year: "numeric",
     month: "numeric",
@@ -14,18 +22,80 @@
     hour: "numeric",
     minute: "numeric",
   } as const;
-  const formatMsAsDateTime = (value: number) => Intl.DateTimeFormat(undefined, formatterOptions).format(msToSeconds(value));
+  const formatSecondsAsDateTime = (seconds: number) => Intl.DateTimeFormat(undefined, formatterOptions).format(secondsToMs(seconds));
+
+
+  const remoteData = writable<TRaindrop[]>([]);
+  const requestsInFlight = writable(0);
+  const mostRecentRequestTime = writable(new Date(0));
+  const loading = derived(
+    requestsInFlight,
+    ($requestsInFlight) => $requestsInFlight > 0
+  );
+  const sinceLastUpdate = derived(
+    [remoteData, lastSyncTimestampSecs],
+    ([$remoteData2, $lastSyncDatetime]) => {
+      const lastSyncDate = new Date($lastSyncDatetime * 1000);
+      return $remoteData2.filter((raindrop) => raindrop.created > lastSyncDate);
+    }
+  )
+
+
+  const performSearch = async (): Promise<void> => {
+    const requestTime = new Date();
+    requestsInFlight.update((n) => n + 1);
+
+    const res = await fetch(
+      `https://api.raindrop.io/rest/v1/raindrops/0?sort=-created&perpage=40&version=2`,
+      {
+        method: "GET",
+        headers: new Headers({
+          Authorization: `Bearer ${settings.access_token()}`,
+          "Content-Type": "application/json",
+        }),
+      }
+    );
+    const { items } = await res.json();
+
+    requestsInFlight.update((n) => n - 1);
+    mostRecentRequestTime.update((currentRequestTime) => {
+      if (requestTime < currentRequestTime) return currentRequestTime;
+      remoteData.update((_) => items.map(raindropTransformer));
+      return requestTime;
+    });
+  };
+  const onSearch = (): void => {
+    performSearch();
+  };
 </script>
 
 {#if hasEnabledExperimentalFeatures}
 <div class="experimental">
   <h3>Import Recently Added</h3>
   <p>Bookmarks new to your Raindrop. This does not include old bookmarks that you've recently updated by adding new tags or annotations.</p>
-  <button>Fetch new bookmarks</button>
+  <button on:click={onSearch}>Fetch new bookmarks</button>
   <form class="sync-container">
-    <label for="last-sync">Last sync: {formatMsAsDateTime($lastSyncDatetime)}</label>
-    <input id="last-sync" type="text" bind:value={$lastSyncDatetime}/>
+    <label for="last-sync">Last sync: {formatSecondsAsDateTime($lastSyncTimestampSecs)}</label>
+    <input id="last-sync" type="text" bind:value={$lastSyncTimestampValueStr}/>
   </form>
+
+  <div>
+    <h4>Raindrops since last sync</h4>
+    {#each $sinceLastUpdate as result}
+      <Raindrop 
+        full={false}
+        title={result.title}
+        description={result?.description}
+        annotations={result?.annotations}
+        tags={result?.tags}
+        url={result?.url}
+        created={result?.created}
+        collectionName={result?.collectionName}
+        coverImage={result?.coverImage}
+        onClick={() => console.log("ok")}
+      />
+    {/each}
+  </div>
 </div>
 {/if}
 

--- a/src/importHighlights.ts
+++ b/src/importHighlights.ts
@@ -1,0 +1,91 @@
+import type { IBatchBlock } from "@logseq/libs/dist/LSPlugin.user.js";
+import { getOrCreateBlockInPage } from "@queries/getOrCreateBlockInPage.js";
+import { getOrCreatePageByName } from "@queries/getOrCreatePage.js";
+import type { LogseqServiceClient } from "@services/interfaces.js";
+import { createCollectionUpdatedSinceGenerator } from "@services/raindrop/collection.js";
+import { importFilterOptions } from "@util/settings.js";
+
+export const importHighlightsSinceLastSync = async (
+  lastSync: Date,
+  logseqClient: LogseqServiceClient,
+  pageName: string
+) => {
+  // get Raindrop page, or create it if it doesn't exist
+  const page = await getOrCreatePageByName(logseqClient, pageName);
+  if (page.isErr) {
+    throw new Error(
+      "Failed to import pages, could not create page to put highlights into"
+    );
+  }
+
+  // Get the block under which we import the page, and underneath that, the
+  // highlights. This generally looks like `# Articles`, and is one of the first
+  // children of the page.
+  const articleListParentBlock = await getOrCreateBlockInPage(
+    logseqClient,
+    page.value.uuid,
+    (block) => block.content === "# Articles",
+    "# Articles"
+  );
+  if (articleListParentBlock.isErr) {
+    throw new Error(
+      "Failed to import pages, could not create block to put highlights into"
+    );
+  }
+
+  const generator = createCollectionUpdatedSinceGenerator(lastSync);
+
+  // iterate over generator pages
+  for await (const raindropListWindow of generator) {
+    raindropListWindow.forEach(async (r) => {
+      const importFilter = await logseqClient.settings.get("import_filter");
+      if (importFilter === importFilterOptions.WITH_ANNOTATIONS) {
+        if (r.annotations.length === 0) return;
+      }
+
+      const articleBlock = await logseqClient.createBlock(
+        articleListParentBlock.value.uuid,
+        `[${r.title}](${r.url})
+        title:: ${r.title}
+        url:: ${r.url}
+        Tags:: ${r.tags.join(", ")}
+        `,
+        { sibling: false }
+      );
+
+      if (!articleBlock) {
+        throw new Error(
+          "Failed to import pages, could not create block to put highlights into"
+        );
+      }
+      // Early return if the page doesn't have any highlights.
+      if (r.annotations.length === 0) return;
+
+      const highlightsBlock = await logseqClient.createBlock(
+        articleBlock.uuid,
+        `## Highlights`,
+        { sibling: false, before: false }
+      );
+      if (!highlightsBlock) {
+        throw new Error(
+          "Failed to import pages, could not create block to put highlights into"
+        );
+      }
+
+      // batch import highlights
+      const highlightBatch = r.annotations.map(
+        (a): IBatchBlock => ({
+          content: [`> ${a.text}`, "", `${a.note}`].join("\n"),
+        })
+      );
+      await logseqClient.createBlockBatch(
+        highlightsBlock.uuid,
+        highlightBatch,
+        {
+          before: true,
+          sibling: false,
+        }
+      );
+    });
+  }
+};

--- a/src/queries/getOrCreateBlockInPage.ts
+++ b/src/queries/getOrCreateBlockInPage.ts
@@ -1,0 +1,39 @@
+import type {
+  LSBlockEntity,
+  LogseqServiceClient,
+} from "@services/interfaces.js";
+import type { Result } from "true-myth";
+import { ok, err } from "true-myth/result";
+
+/**
+ * Returns the first block in a page identified by `pageUuid` that matches
+ * `matcher`. If not block matches, a new block is created.
+ * @param logseqClient Client for interacting with Logseq.
+ * @param pageUuid UUID of the page to search.
+ * @param matcher Function that returns true if the block is returnable.
+ * @param newBlockContent Content for the new block, if none match.
+ * @returns A Promise that resolves to the created block, or an error if a block
+ * could not be created.
+ */
+export const getOrCreateBlockInPage = async (
+  logseqClient: LogseqServiceClient,
+  pageUuid: string,
+  matcher: (block: LSBlockEntity) => boolean,
+  newBlockContent: string
+): Promise<Result<LSBlockEntity, Error>> => {
+  const pageBlockTree = await logseqClient.getBlockTreeForPage(pageUuid);
+  const block = pageBlockTree.find(matcher);
+  if (block) return ok(block);
+
+  const createdBlock = await logseqClient.createBlock(
+    pageUuid,
+    newBlockContent,
+    {
+      sibling: true,
+      before: false,
+    }
+  );
+  if (createdBlock) return ok(createdBlock);
+
+  return err(new Error("Failed to create block"));
+};

--- a/src/queries/getOrCreatePage.ts
+++ b/src/queries/getOrCreatePage.ts
@@ -1,0 +1,24 @@
+import type { Result } from "true-myth";
+import { err, ok } from "true-myth/result";
+
+import type {
+  LSPageEntity,
+  LogseqServiceClient,
+} from "@services/interfaces.js";
+
+export const getOrCreatePageByName = async (
+  logseqClient: LogseqServiceClient,
+  pageName: string
+): Promise<Result<LSPageEntity, Error>> => {
+  const page = await logseqClient.getPageByName(pageName);
+  if (page) return ok(page);
+
+  const createdPage = await logseqClient.createPage(
+    pageName,
+    {},
+    { createFirstBlock: false }
+  );
+  if (createdPage) return ok(createdPage);
+
+  return err(new Error("Failed to create page"));
+};

--- a/src/services/interfaces.ts
+++ b/src/services/interfaces.ts
@@ -3,6 +3,7 @@ import type {
   BlockUUID,
   BlockUUIDTuple,
   EntityID,
+  IBatchBlock,
   IEntityID,
   PageEntity,
   SettingSchemaDesc,
@@ -169,6 +170,25 @@ export interface LogseqServiceClient {
   ) => Promise<LSBlockEntity | null>;
 
   /**
+   * Batched version of `creatBlock`. Creates multiple blocks in a single call.
+   *
+   * @see createBlock
+   *
+   * @param refenceBlockUuid
+   * @param blocks
+   * @param options
+   * @returns
+   */
+  createBlockBatch: (
+    refenceBlockUuid: BlockUUID,
+    blocks: IBatchBlock[],
+    options?: {
+      before?: boolean;
+      sibling?: boolean;
+    }
+  ) => Promise<LSBlockEntity[] | null>;
+
+  /**
    * Opens a page so that it's viewable in Logseq.
    *
    * @param pageName The name of the page to open.
@@ -270,6 +290,11 @@ export interface LogseqServiceClient {
    * Returns the PageEntity, if one exists, for a Page UUID.
    */
   getPageByUuid: (pageUuid: BlockUUID) => Promise<LSPageEntity | null>;
+
+  /**
+   * Returns the PageEntity, if one exists, for a Page UUID.
+   */
+  getPageByName: (pageName: string) => Promise<LSPageEntity | null>;
 
   /**
    * Returns all the blocks for the specific page.

--- a/src/services/logseq/client.ts
+++ b/src/services/logseq/client.ts
@@ -20,6 +20,8 @@ export const generateLogseqClient = (): LogseqServiceWrapper => {
     // Block
     createBlock: async (parentBlockUuid, blockContent, blockOptions) =>
       logseq.Editor.insertBlock(parentBlockUuid, blockContent, blockOptions),
+    createBlockBatch: async (parentBlockUuid, blocks, batchOptions) =>
+      logseq.Editor.insertBatchBlock(parentBlockUuid, blocks, batchOptions),
     deleteBlock: async (blockUuid) => logseq.Editor.removeBlock(blockUuid),
     getBlockById: async (blockUuid) => logseq.Editor.getBlock(blockUuid),
     getPropertiesForBlock: async (blockUuid) =>
@@ -66,6 +68,10 @@ export const generateLogseqClient = (): LogseqServiceWrapper => {
     getPageByUuid: async (id) => {
       if (typeof id !== "string") return null;
       return logseq.Editor.getPage(id);
+    },
+    getPageByName: async (name) => {
+      if (typeof name !== "string") return null;
+      return logseq.Editor.getPage(name);
     },
     settings: {
       get: async (key) => logseq.settings![key],

--- a/src/services/raindrop/collection.spec.ts
+++ b/src/services/raindrop/collection.spec.ts
@@ -2,7 +2,7 @@ import { assert, describe, expect, it, vi } from "vitest";
 
 import { createCollectionUpdatedSinceGenerator } from "./collection.js";
 import { httpClient } from "./http.js";
-import { generateRaindrop } from "src/testing/raindropFactory.js";
+import { generateRaindropResponse } from "src/testing/raindropFactory.js";
 
 vi.mock("./http.js", () => {
   const get = vi.fn();
@@ -36,13 +36,13 @@ describe("getCollectionUpdatedSince", () => {
   it("returns a list of raindrops", async () => {
     vi.mocked(httpClient)!.get.mockResolvedValueOnce(
       createMockHttpClientResponse([
-        generateRaindrop({
+        generateRaindropResponse({
           title: "Raindrop 1",
-          lastUpdate: new Date("2020-01-01T00:00:00.000Z"),
+          lastUpdate: new Date("2020-01-01T00:00:00.000Z").toISOString(),
         }),
-        generateRaindrop({
+        generateRaindropResponse({
           title: "Raindrop 2",
-          lastUpdate: new Date("2020-01-02T00:00:00.000Z"),
+          lastUpdate: new Date("2020-01-02T00:00:00.000Z").toISOString(),
         }),
       ])
     );
@@ -60,13 +60,13 @@ describe("getCollectionUpdatedSince", () => {
   it("only returns raindrops updated since the given date", async () => {
     vi.mocked(httpClient)!.get.mockResolvedValueOnce(
       createMockHttpClientResponse([
-        generateRaindrop({
+        generateRaindropResponse({
           title: "Raindrop 1",
-          lastUpdate: new Date("1999-01-01T00:00:00.000Z"),
+          lastUpdate: new Date("1999-01-01T00:00:00.000Z").toISOString(),
         }),
-        generateRaindrop({
+        generateRaindropResponse({
           title: "Raindrop 2",
-          lastUpdate: new Date("2020-01-02T00:00:00.000Z"),
+          lastUpdate: new Date("2020-01-02T00:00:00.000Z").toISOString(),
         }),
       ])
     );
@@ -85,9 +85,9 @@ describe("getCollectionUpdatedSince", () => {
     const moreRecentThanPastDate = new Date("2020-01-01T00:00:00.000Z");
     vi.mocked(httpClient)!.get.mockResolvedValueOnce(
       createMockHttpClientResponse([
-        generateRaindrop({
+        generateRaindropResponse({
           title: "Raindrop 1",
-          lastUpdate: moreRecentThanPastDate,
+          lastUpdate: moreRecentThanPastDate.toISOString(),
         }),
       ])
     );
@@ -103,9 +103,9 @@ describe("getCollectionUpdatedSince", () => {
     // Second page of data
     vi.mocked(httpClient)!.get.mockResolvedValueOnce(
       createMockHttpClientResponse([
-        generateRaindrop({
+        generateRaindropResponse({
           title: "Raindrop 2",
-          lastUpdate: moreRecentThanPastDate,
+          lastUpdate: moreRecentThanPastDate.toISOString(),
         }),
       ])
     );

--- a/src/services/raindrop/collection.spec.ts
+++ b/src/services/raindrop/collection.spec.ts
@@ -1,0 +1,131 @@
+import { assert, describe, expect, it, vi } from "vitest";
+
+import { createCollectionUpdatedSinceGenerator } from "./collection.js";
+import { httpClient } from "./http.js";
+import { generateRaindrop } from "src/testing/raindropFactory.js";
+
+vi.mock("./http.js", () => {
+  const get = vi.fn();
+  const post = vi.fn();
+
+  return { httpClient: { get, post } };
+});
+
+/**
+ * Creates a barely valid mock HTTP client response.
+ * Do not trust this function to generate a valid Response. It probably is not
+ * doing what you want it to.
+ *
+ * @param raindropResponseItems An array of raindrops to return
+ * @returns A mock HTTP client response.
+ */
+const createMockHttpClientResponse = (
+  raindropResponseItems: unknown[]
+): Response => {
+  return {
+    json: async () => {
+      return {
+        items: raindropResponseItems,
+        count: raindropResponseItems.length,
+      };
+    },
+  } as unknown as Response;
+};
+
+describe("getCollectionUpdatedSince", () => {
+  it("returns a list of raindrops", async () => {
+    vi.mocked(httpClient)!.get.mockResolvedValueOnce(
+      createMockHttpClientResponse([
+        generateRaindrop({
+          title: "Raindrop 1",
+          lastUpdate: new Date("2020-01-01T00:00:00.000Z"),
+        }),
+        generateRaindrop({
+          title: "Raindrop 2",
+          lastUpdate: new Date("2020-01-02T00:00:00.000Z"),
+        }),
+      ])
+    );
+    const raindrops = await createCollectionUpdatedSinceGenerator(
+      new Date("2020-01-01"),
+      "0"
+    ).next();
+
+    assert(raindrops.value);
+    expect(raindrops.value.length).toBe(2);
+    expect(raindrops.value.at(0)).toHaveProperty("title", "Raindrop 1");
+    expect(raindrops.value.at(1)).toHaveProperty("title", "Raindrop 2");
+  });
+
+  it("only returns raindrops updated since the given date", async () => {
+    vi.mocked(httpClient)!.get.mockResolvedValueOnce(
+      createMockHttpClientResponse([
+        generateRaindrop({
+          title: "Raindrop 1",
+          lastUpdate: new Date("1999-01-01T00:00:00.000Z"),
+        }),
+        generateRaindrop({
+          title: "Raindrop 2",
+          lastUpdate: new Date("2020-01-02T00:00:00.000Z"),
+        }),
+      ])
+    );
+    const raindrops = await createCollectionUpdatedSinceGenerator(
+      new Date("2020-01-02"),
+      "0"
+    ).next();
+
+    assert(raindrops.value);
+    expect(raindrops.value.length).toBe(1);
+    expect(raindrops.value.at(0)).toHaveProperty("title", "Raindrop 2");
+  });
+
+  it("returns pages of raindrops", async () => {
+    const pastDate = new Date("2019-01-01T00:00:00.000Z");
+    const moreRecentThanPastDate = new Date("2020-01-01T00:00:00.000Z");
+    vi.mocked(httpClient)!.get.mockResolvedValueOnce(
+      createMockHttpClientResponse([
+        generateRaindrop({
+          title: "Raindrop 1",
+          lastUpdate: moreRecentThanPastDate,
+        }),
+      ])
+    );
+    const generator = createCollectionUpdatedSinceGenerator(pastDate, "0");
+
+    // First page of data
+    const actual1 = await generator.next();
+
+    assert(actual1.value);
+    expect(actual1.value.length).toBe(1);
+    expect(actual1.value.at(0)).toHaveProperty("title", "Raindrop 1");
+
+    // Second page of data
+    vi.mocked(httpClient)!.get.mockResolvedValueOnce(
+      createMockHttpClientResponse([
+        generateRaindrop({
+          title: "Raindrop 2",
+          lastUpdate: moreRecentThanPastDate,
+        }),
+      ])
+    );
+
+    const actual2 = await generator.next();
+
+    assert(actual2.value);
+    expect(actual2.value.length).toBe(1);
+    expect(actual2.value.at(0)).toHaveProperty("title", "Raindrop 2");
+  });
+
+  it("returns done when there are no more raindrops", async () => {
+    vi.mocked(httpClient)!.get.mockResolvedValueOnce(
+      createMockHttpClientResponse([])
+    );
+    const generator = createCollectionUpdatedSinceGenerator(
+      new Date("2020-01-01"),
+      "0"
+    );
+    const actual = await generator.next();
+    expect(actual.done).toBe(true);
+  });
+});

--- a/src/services/raindrop/collection.ts
+++ b/src/services/raindrop/collection.ts
@@ -1,9 +1,12 @@
-import type { Raindrop } from "@types";
 import { httpClient } from "./http.js";
+import {
+  raindropTransformer,
+  type RaindropResponse,
+} from "@util/raindropTransformer.js";
 
 type CollectionResponse = {
   result: boolean;
-  items: Raindrop[];
+  items?: RaindropResponse[];
   count: number;
   collectionId: "string";
 };
@@ -53,12 +56,12 @@ export async function* createCollectionUpdatedSinceGenerator(
       }&page=${pageOffset}`
     );
     const raindrops = (await response.json()) as CollectionResponse;
-    const raindropsUpdatedSince = raindrops.items.filter(
+    const raindropsUpdatedSince = (raindrops.items ?? []).filter(
       (r) => new Date(r.lastUpdate) >= since
     );
 
     if (raindropsUpdatedSince.length === 0) break;
-    yield raindropsUpdatedSince;
+    yield raindropsUpdatedSince.map(raindropTransformer);
 
     pageOffset += 1;
   }

--- a/src/services/raindrop/collection.ts
+++ b/src/services/raindrop/collection.ts
@@ -7,3 +7,18 @@ export const searchTerm = async (query: string, collectionId: string = "0") => {
 
   return httpClient.get(`/raindrops/${collectionId}?search=${query}`);
 };
+
+export async function* getCollectionUpdatedSince(
+  since: Date,
+  collectionId: string = "0",
+  params?: {
+    perPage?: number;
+  }
+) {
+  let pageOffset = 0;
+  yield httpClient.get(
+    `/raindrops/${collectionId}?sort-lastUpdate&perpage=${
+      params?.perPage ?? 10
+    }&page=${pageOffset}`
+  );
+}

--- a/src/services/raindrop/collection.ts
+++ b/src/services/raindrop/collection.ts
@@ -1,4 +1,12 @@
+import type { Raindrop } from "@types";
 import { httpClient } from "./http.js";
+
+type CollectionResponse = {
+  result: boolean;
+  items: Raindrop[];
+  count: number;
+  collectionId: "string";
+};
 
 export const searchTerm = async (query: string, collectionId: string = "0") => {
   if (!httpClient) {
@@ -8,17 +16,51 @@ export const searchTerm = async (query: string, collectionId: string = "0") => {
   return httpClient.get(`/raindrops/${collectionId}?search=${query}`);
 };
 
-export async function* getCollectionUpdatedSince(
+/**
+ * Creates a generator that returns a list of Raindrops that have been updated
+ * after the given `since` date.
+ *
+ * @param since A date, used to keep only the raindrops updated since this date.
+ * @param collectionId The id of the collection to fetch.
+ * @param params Additional query parameters
+ * @returns A generator that can be used to get each page of results.
+ *
+ * @example
+ * const raindrops = await createCollectionUpdatedSinceGenerator(
+ *   new Date("2020-01-01"),
+ *   "0"
+ * ).next();
+ * // raindrops is an object with a done and a value
+ * // the generator is done when there is no more content.
+ * // value is a list of Raindrops
+ */
+export async function* createCollectionUpdatedSinceGenerator(
   since: Date,
   collectionId: string = "0",
   params?: {
     perPage?: number;
   }
 ) {
+  if (!httpClient) {
+    throw new Error("Raindrop client not initialized");
+  }
   let pageOffset = 0;
-  yield httpClient.get(
-    `/raindrops/${collectionId}?sort-lastUpdate&perpage=${
-      params?.perPage ?? 10
-    }&page=${pageOffset}`
-  );
+
+  while (true) {
+    const response = await httpClient.get(
+      `/raindrops/${collectionId}?sort-lastUpdate&perpage=${
+        params?.perPage ?? 10
+      }&page=${pageOffset}`
+    );
+    const raindrops = (await response.json()) as CollectionResponse;
+    const raindropsUpdatedSince = raindrops.items.filter(
+      (r) => new Date(r.lastUpdate) >= since
+    );
+
+    if (raindropsUpdatedSince.length === 0) break;
+    yield raindropsUpdatedSince;
+
+    pageOffset += 1;
+  }
+  return;
 }

--- a/src/stores/userPreferences.ts
+++ b/src/stores/userPreferences.ts
@@ -3,6 +3,7 @@ import { writable } from "svelte/store";
 type UserPreferences = {
   broken_experimental_features: boolean;
   last_sync_timestamp: number;
+  sync_to_single_page: boolean;
 };
 
 function createUserPreferences() {

--- a/src/stores/userPreferences.ts
+++ b/src/stores/userPreferences.ts
@@ -1,0 +1,31 @@
+import { writable } from "svelte/store";
+
+type UserPreferences = {
+  broken_experimental_features: boolean;
+  last_sync_timestamp: number;
+};
+
+function createUserPreferences() {
+  const { subscribe, set, update } = writable<UserPreferences>(
+    {} as UserPreferences
+  );
+
+  return {
+    subscribe,
+    onUpdate: (after: UserPreferences, _before: UserPreferences) => {
+      set(after);
+    },
+    updateSetting: <Key extends keyof UserPreferences>(
+      settingId: Key,
+      value: UserPreferences[Key]
+    ) => {
+      // Update the in-memory store
+      update((currentValue) => ({ ...currentValue, [settingId]: value }));
+      // Update settings on disk
+      logseq.updateSettings({ [settingId]: value });
+    },
+    reset: () => set({} as UserPreferences),
+  };
+}
+
+export const userPreferences = createUserPreferences();

--- a/src/testing/raindropFactory.ts
+++ b/src/testing/raindropFactory.ts
@@ -1,4 +1,5 @@
 import type { Annotation, Raindrop } from "@types";
+import type { RaindropResponse } from "@util/raindropTransformer.js";
 import { randomUUID } from "crypto";
 
 const generateAnnotation = (opts?: Partial<Annotation>): Annotation => ({
@@ -20,6 +21,39 @@ const runRandomNumberOfTimes = (generator: () => Annotation) => {
 
   return returnable;
 };
+
+export const generateRaindropResponse = (
+  opts?: Partial<RaindropResponse>
+): RaindropResponse => {
+  return {
+    _id: opts?._id ?? Math.random() * 10000,
+    link: opts?.link ?? `https://www.${randomUUID()}.com`,
+    title: opts?.title ?? randomUUID(),
+    created: opts?.created ?? new Date().toISOString(),
+    lastUpdate: opts?.lastUpdate ?? new Date().toISOString(),
+    media: opts?.media ?? ([] as unknown as [{ link: string }]),
+    user: opts?.user ?? ({} as RaindropResponse["user"]),
+    collection: opts?.collection ?? ({} as RaindropResponse["collection"]),
+    highlights:
+      opts?.highlights ?? ([] as unknown as RaindropResponse["highlights"]),
+    domain: opts?.domain ?? randomUUID(),
+    creatorRef: opts?.creatorRef ?? ({} as RaindropResponse["creatorRef"]),
+    sort: opts?.sort ?? 0,
+    cache: opts?.cache ?? {
+      status: "ready",
+      size: 0,
+      created: new Date().toISOString(),
+    },
+    collectionId: opts?.collectionId ?? 0,
+    excerpt: opts?.excerpt ?? randomUUID(),
+    note: opts?.note ?? randomUUID(),
+    type: opts?.type ?? "link",
+    cover: opts?.cover ?? randomUUID(),
+    tags: opts?.tags ?? [],
+    removed: opts?.removed ?? false,
+  };
+};
+
 export const generateRaindrop = (opts?: Partial<Raindrop>): Raindrop => {
   return {
     title: opts?.title ?? randomUUID(),

--- a/src/testing/raindropFactory.ts
+++ b/src/testing/raindropFactory.ts
@@ -1,0 +1,36 @@
+import type { Annotation, Raindrop } from "@types";
+import { randomUUID } from "crypto";
+
+const generateAnnotation = (opts?: Partial<Annotation>): Annotation => ({
+  note: opts?.note ?? randomUUID(),
+  color: opts?.color ?? "blue",
+  text: opts?.text ?? randomUUID(),
+  created: opts?.created ?? new Date(),
+  id: opts?.id ?? randomUUID(),
+  ...opts,
+});
+
+const runRandomNumberOfTimes = (generator: () => Annotation) => {
+  const numberOfTimes = Math.random() * 5;
+  const returnable = [];
+
+  for (let i = 0; i < numberOfTimes; i++) {
+    returnable.push(generator());
+  }
+
+  return returnable;
+};
+export const generateRaindrop = (opts?: Partial<Raindrop>): Raindrop => {
+  return {
+    title: opts?.title ?? randomUUID(),
+    description: opts?.description ?? randomUUID(),
+    annotations:
+      opts?.annotations ?? runRandomNumberOfTimes(generateAnnotation),
+    tags: opts?.tags ?? [],
+    coverImage: opts?.coverImage ?? randomUUID(),
+    created: opts?.created ?? new Date(),
+    lastUpdate: opts?.lastUpdate ?? new Date(),
+    url: opts?.url ?? new URL("https://example.com"),
+    id: opts?.id ?? randomUUID(),
+  };
+};

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -17,6 +17,7 @@ export type Raindrop = {
   tags: Tag[];
   coverImage: string;
   created: Date;
+  lastUpdate: Date;
   url: URL;
   collectionName?: string;
   id: ID;

--- a/src/util/raindropTransformer.ts
+++ b/src/util/raindropTransformer.ts
@@ -88,6 +88,7 @@ export const raindropTransformer = (r: RaindropResponse): Raindrop => {
     coverImage: r.cover,
     url: new URL(r.link),
     created: new Date(r.created),
+    lastUpdate: new Date(r.lastUpdate),
     tags: r.tags,
     annotations,
   };

--- a/src/util/raindropTransformer.ts
+++ b/src/util/raindropTransformer.ts
@@ -13,7 +13,7 @@ type HighlightsColor =
   | "red"
   | "teal"
   | "yellow";
-type RaindropResponse = {
+export type RaindropResponse = {
   excerpt: string;
   note: string;
   type: "link" | "article" | "image" | "video" | "document" | "audio";

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -1,7 +1,41 @@
 import type { SettingSchemaDesc } from "@logseq/libs/dist/LSPlugin.js";
 import { userPreferences } from "src/stores/userPreferences.js";
 
+export const importFilterOptions = {
+  ALL: "Import all Raindrops",
+  WITH_ANNOTATIONS: "Import only Raindrops with highlights",
+};
+
 const settingsConfig: SettingSchemaDesc[] = [
+  {
+    default: false,
+    type: "boolean",
+    key: "sync_to_single_page",
+    title: "Sync to a single page?",
+    description:
+      "If enabled, all Raindrops will be imported to a single page, instead of each in their own page under the hierarchy page name." +
+      "\n\n" +
+      "**For example**, when this is off, an article _Great Logseq Plugins_ might be imported in a page `logseq-raindrop/Great Logseq Plugins`." +
+      " With it on, this page would be created as a new block under the page `Raindrop`.",
+  },
+  {
+    default: importFilterOptions.ALL,
+    type: "enum",
+    enumChoices: Object.values(importFilterOptions),
+    enumPicker: "select",
+    key: "import_filter",
+    title: "Which Raindrops should be imported?",
+    description:
+      "When you import Raindrops to a single page, choose which Raindrops you import. The default is to import all of them, but you can choose to only import Raindrops with highlights.",
+  },
+  {
+    default: "Raindrop",
+    type: "string",
+    key: "page_name",
+    title: "Page Name for Single Page imports",
+    description:
+      "If 'Sync to a single page?' is enabled, all Raindrops will be imported to this page. It will be created if it does not exist.",
+  },
   {
     default: "",
     description:
@@ -38,7 +72,11 @@ const settingsConfig: SettingSchemaDesc[] = [
     default: "logseq-raindrop",
     title: "Hierarchy parent page name",
     description:
-      "The page under which all imported pages are put. By default, pages are created with a title like 'logseq-raindrop/My Imported Page Name'. If you **do not** want namespaced pages, you can leave this empty.",
+      "The page under which all imported pages are put." +
+      " By default, pages are created with a title like 'logseq-raindrop/My Imported Page Name'." +
+      " If you **do not** want namespaced pages, you can leave this empty." +
+      "\n\n" +
+      "Note: this setting is **unused** if 'Sync to a single page?' is enabled.",
     key: "namespace_label",
     type: "string",
   },
@@ -88,6 +126,8 @@ export const settings = {
   namespace_label: (): string => logseq.settings!["namespace_label"] as string,
   default_page_tags: (): string =>
     logseq.settings!["default_page_tags"] as string,
+  import_filter: () =>
+    logseq.settings!["import_filter"] as keyof typeof importFilterOptions,
   formatting_template: {
     highlight: (): string => logseq.settings!["template_highlight"] as string,
     annotation: (): string => logseq.settings!["template_annotation"] as string,

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -1,4 +1,5 @@
 import type { SettingSchemaDesc } from "@logseq/libs/dist/LSPlugin.js";
+import { userPreferences } from "src/stores/userPreferences.js";
 
 const settingsConfig: SettingSchemaDesc[] = [
   {
@@ -67,6 +68,14 @@ const settingsConfig: SettingSchemaDesc[] = [
       "\n\n" +
       "If you disable this, no blocks will be added but **you will have to delete existing blocks manually**.",
   },
+  {
+    default: 0,
+    title: "Last sync timestamp (milliseconds)",
+    description:
+      "The time of the last sync from the unix epoch. Used to determine which bookmarks have been created since the last sync. You can clear this value to reimport all bookmarks.",
+    key: "last_sync_timestamp",
+    type: "number",
+  },
 ];
 
 /**
@@ -92,5 +101,7 @@ export const settings = {
  *
  */
 export const registerSettings = (): void => {
+  logseq.onSettingsChanged(userPreferences.onUpdate);
+
   logseq.useSettingsSchema(settingsConfig);
 };

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -73,8 +73,8 @@ const settingsConfig: SettingSchemaDesc[] = [
  * Properties within the object return current setting values.
  */
 export const settings = {
-  enable_broken_experimental_features: (): string =>
-    logseq.settings!["broken_experimental_features"] as string,
+  enable_broken_experimental_features: () =>
+    logseq.settings!["broken_experimental_features"] as boolean,
   access_token: (): string => logseq.settings!["access_token"] as string,
   namespace_label: (): string => logseq.settings!["namespace_label"] as string,
   default_page_tags: (): string =>

--- a/src/util/time.ts
+++ b/src/util/time.ts
@@ -1,0 +1,22 @@
+/**
+ * Converts a number of seconds to milliseconds.
+ * @param seconds The number of seconds to convert.
+ * @returns The number of milliseconds.
+ */
+const secondsToMs = (seconds: number) => seconds * 1000;
+
+const formatterOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+} as const;
+
+/**
+ * Converts a number of seconds to a date string formatted like `4/27/2023, 2:11 AM`.
+ * @param seconds The number of seconds to convert.
+ * @returns The date string.
+ */
+export const formatSecondsAsDateTime = (seconds: number) =>
+  Intl.DateTimeFormat(undefined, formatterOptions).format(secondsToMs(seconds));

--- a/src/util/upsertRaindropPage.spec.ts
+++ b/src/util/upsertRaindropPage.spec.ts
@@ -60,6 +60,7 @@ describe("ioMaybeGetPageForRaindrop", () => {
         tags: [],
         coverImage: "",
         created: new Date(),
+        lastUpdate: new Date(),
         url: new URL("https://example.com"),
       },
       logseqClient
@@ -85,6 +86,7 @@ describe("ioMaybeGetPageForRaindrop", () => {
         tags: [],
         coverImage: "",
         created: new Date(),
+        lastUpdate: new Date(),
         url: new URL("https://example.com"),
       },
       logseqClient
@@ -120,6 +122,7 @@ describe("ioCreateOrLoadPage", () => {
         tags: [],
         coverImage: "",
         created: new Date(),
+        lastUpdate: new Date(),
         url: new URL("https://example.com"),
       },
       logseqClient
@@ -203,6 +206,7 @@ describe("ioCreateOrLoadPage", () => {
         tags: [],
         coverImage: "",
         created: new Date(),
+        lastUpdate: new Date(),
         url: new URL("https://example.com"),
       },
       logseqClient
@@ -322,6 +326,7 @@ describe("ioUpsertAnnotationBlocks", () => {
       coverImage: "",
       url: new URL("https://example.com"),
       created: new Date(),
+      lastUpdate: new Date(),
     };
 
     const logseqClient = generateMoqseqClient({
@@ -366,6 +371,7 @@ describe("ioUpsertAnnotationBlocks", () => {
       coverImage: "",
       url: new URL("https://example.com"),
       created: new Date(),
+      lastUpdate: new Date(),
     };
     const raindropAfter: Raindrop = {
       id: "123",
@@ -384,6 +390,7 @@ describe("ioUpsertAnnotationBlocks", () => {
       coverImage: "",
       url: new URL("https://example.com"),
       created: new Date(),
+      lastUpdate: new Date(),
     };
 
     const logseqClient = generateMoqseqClient({


### PR DESCRIPTION
This is the first step towards #38 — it adds a single-page import process similar to how Omnivore works.

- Users can use this **ONLY IF** they enable both "Sync to a single page?" and "Enable broken, experimental features".
- Users can choose whether to import all Raindrops created since the last sync, or only those with highlights.
- Users can change the page Raindrops are imported to ("Page Name for Single Page Imports")

There is no attempt at upserting at the moment — if a Raindrop has been updated after the sync time, it's re-inserted.

I think, at the moment, everything is appended to the bottom. We probably don't want that. There's also no formatting, nor are user's default tags setting respected.

There's tons of clean up / code reorganization to do. Having one giant "importHighlightsSinceLastSync" function gives me no joy, but it does _sort of_ work!

Here's a demo: note that the plugin **does not** redirect to the page by default.

https://github.com/phildenhoff/logseq-raindrop/assets/17505728/bc1ee3d8-967c-4cf6-9f08-39dcca1d1125
