### PR TITLE
Support org-mode using templates

### DIFF
--- a/src/commands/addToRaindrop.ts
+++ b/src/commands/addToRaindrop.ts
@@ -81,6 +81,11 @@ export const addUrlsToRaindrop = async (): Promise<void> => {
 
   const template = settings.formatting_template.add_link_mustache_template();
   const text = renderAddedToRaindrop(newRaindrops, template);
+  if (!text) {
+    logseq.UI.showMsg("Added URLs to Raindrop");
+    return;
+  }
+
   await logseq.Editor.insertBlock(uuid, text, {
     sibling: false,
   });

--- a/src/commands/views.ts
+++ b/src/commands/views.ts
@@ -1,0 +1,6 @@
+export type AddedToRaindropView = {
+  links: Array<{
+    raindropPreviewUrl: string;
+    addedUrl: string;
+  }>;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { registerCommands } from "@commands/commands.js";
 import { registerSettings, settings } from "@util/settings.js";
 import { setupRaindropHttpClient } from "@services/raindrop/index.js";
 
-const main = () => {
+const main = async () => {
   const addColorStyle = import.meta.env.PROD ? "" : "color: orange!important;";
 
   setupRaindropHttpClient({
@@ -16,7 +16,7 @@ const main = () => {
   });
 
   registerCommands();
-  registerSettings();
+  await registerSettings();
 
   new App({
     target: document.getElementById("app")!,

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -6,12 +6,12 @@ export type Template = {
 export const defaultHighlightTemplate: Template = {
   markdown: `> {{{text}}}
 
-  {{{note}}}`,
+{{{note}}}`,
   org: `#+BEGIN_QUOTE
-  {{text}}
-  #+END_QUOTE
+{{text}}
+#+END_QUOTE
 
-  {{note}}`,
+{{note}}`,
 };
 
 export const defaultBookmarkTemplate: Template = {
@@ -19,27 +19,23 @@ export const defaultBookmarkTemplate: Template = {
 title:: {{{title}}}
 url:: {{{url}}}
 Tags:: {{{tags}}}
-date-saved:: [[{{{dateCreated}}}]]
-`,
+date-saved:: [[{{{dateCreated}}}]]`,
   org: `[[{{{url}}}][{{{title}}}]]
 :PROPERTIES:
 :title: {{{title}}}
 :url: {{{url}}}
 :Tags: {{{tags}}}
 :date-saved: [[{{{dateCreated}}}]]
-:END:
-`,
+:END:`,
 };
 
 export const defaultSavedToRaindropTemplate: Template = {
   markdown: `Saved to Raindrop: 
 {{{#links}}}
 {{{.}}}
-{{{/links}}}
-`,
+{{{/links}}}`,
   org: `Saved to Raindrop:
 {{{#links}}}
 {{{.}}}
-{{{/links}}}
-`,
+{{{/links}}}`,
 };

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,45 @@
+export type Template = {
+  markdown: string;
+  org: string;
+};
+
+export const defaultHighlightTemplate: Template = {
+  markdown: `> {{{text}}}
+
+  {{{note}}}`,
+  org: `#+BEGIN_QUOTE
+  {{text}}
+  #+END_QUOTE
+
+  {{note}}`,
+};
+
+export const defaultBookmarkTemplate: Template = {
+  markdown: `[{{{title}}}]({{{url}}})
+title:: {{{title}}}
+url:: {{{url}}}
+Tags:: {{{tags}}}
+date-saved:: [[{{{dateCreated}}}]]
+`,
+  org: `[[{{{url}}}][{{{title}}}]]
+:PROPERTIES:
+:title: {{{title}}}
+:url: {{{url}}}
+:Tags: {{{tags}}}
+:date-saved: [[{{{dateCreated}}}]]
+:END:
+`,
+};
+
+export const defaultSavedToRaindropTemplate: Template = {
+  markdown: `Saved to Raindrop: 
+{{{#links}}}
+{{{.}}}
+{{{/links}}}
+`,
+  org: `Saved to Raindrop:
+{{{#links}}}
+{{{.}}}
+{{{/links}}}
+`,
+};

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -29,13 +29,13 @@ date-saved:: [[{{{dateCreated}}}]]`,
 :END:`,
 };
 
-export const defaultSavedToRaindropTemplate: Template = {
+export const defaultAddedToRaindropTemplate: Template = {
   markdown: `Saved to Raindrop: 
-{{{#links}}}
-{{{.}}}
-{{{/links}}}`,
+{{#links}}
+[\`{{{addedUrl}}}\` (Raindrop preview)]({{{raindropPreviewUrl}}})
+{{/links}}`,
   org: `Saved to Raindrop:
-{{{#links}}}
-{{{.}}}
-{{{/links}}}`,
+{{#links}}
+[[{{{raindropPreviewUrl}}}][~{{{addedUrl}}}~ (Raindrop preview)]]
+{{/links}}`,
 };

--- a/src/util/settings.ts
+++ b/src/util/settings.ts
@@ -3,6 +3,7 @@ import { userPreferences } from "src/stores/userPreferences.js";
 import {
   defaultBookmarkTemplate,
   defaultHighlightTemplate,
+  defaultAddedToRaindropTemplate,
 } from "src/templates.js";
 
 export const importFilterOptions = {
@@ -47,6 +48,15 @@ const generateSettingsConfig = (userConfig: {
       "Enable pre-release features that are not yet ready for general use.",
     key: "broken_experimental_features",
     type: "boolean",
+  },
+  {
+    title: "Add Link to Raindrop template",
+    type: "string",
+    inputAs: "textarea",
+    key: "add_link_mustache_template",
+    description:
+      "Mustache template used when adding a link to Raindrop. Available variables: `{links}` (an array of links added to Raindrop, each with an `{addedUrl}` and `{raindropPreviewUrl}`).",
+    default: defaultAddedToRaindropTemplate[userConfig.preferredFormat],
   },
   {
     key: "category_single-page-imports",
@@ -180,6 +190,8 @@ export const settings = {
     highlight: (): string => logseq.settings!["template_highlight"] as string,
     annotation: (): string => logseq.settings!["template_annotation"] as string,
     deleted: (): string => logseq.settings!["template_deleted"] as string,
+    add_link_mustache_template: (): string =>
+      logseq.settings!["add_link_mustache_template"] as string,
   },
   sync_to_single_page: (): boolean =>
     logseq.settings!["sync_to_single_page"] as boolean,


### PR DESCRIPTION
- For first-time users (or anyone that doesn't have the `add_link_mustache_template`, `bookmark_mustache_template`, or `highlight_mustache_template` settings already set up), we now use org-mode templates if the user has chosen that as their preferred format.

- For all users, there is now a template for the block that is inserted when you use the "Add URLs to Raindrop" slash command. If the template is empty, no block is inserted, and a toast message appears instead.

Closes #70
Closes #71
Closes #72