### PR TITLE
Reorg service modules to hide implementation details

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,7 +6,7 @@
   import { ifIsEnter, ifIsEscape } from "@util/keyboardEvents.js";
   import SinglePageSyncMenu from "@organisms/SinglePageSyncMenu.svelte";
   import type { LogseqServiceClient } from "@services/logseq";
-  import { logseqClientCtxKey } from "@services/logseq/client.js";
+  import { logseqClientCtxKey } from "@services/logseq";
   import ThemeProvider from "@atoms/ThemeProvider.svelte";
 
   import { startSync } from "./sync.js";

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -5,7 +5,7 @@
   import ImportRaindrops from "@organisms/ImportRaindrops.svelte";
   import { ifIsEnter, ifIsEscape } from "@util/keyboardEvents.js";
   import SinglePageSyncMenu from "@organisms/SinglePageSyncMenu.svelte";
-  import type { LogseqServiceClient } from "@services/interfaces.js";
+  import type { LogseqServiceClient } from "@services/logseq";
   import { logseqClientCtxKey } from "@services/logseq/client.js";
   import ThemeProvider from "@atoms/ThemeProvider.svelte";
 

--- a/src/bookmarks/rendering.ts
+++ b/src/bookmarks/rendering.ts
@@ -1,7 +1,7 @@
 import Mustache from "mustache";
 
 import type { AppUserConfigs } from "@logseq/libs/dist/LSPlugin.user.js";
-import { formatDateUserPreference } from "@services/logseq/formatting.js";
+import { formatDateUserPreference } from "@services/logseq";
 
 import type { Annotation, Raindrop } from "@types";
 

--- a/src/commands/addToRaindrop.ts
+++ b/src/commands/addToRaindrop.ts
@@ -1,7 +1,7 @@
 import Mustache from "mustache";
 import { isOk, type Ok } from "true-myth/result";
 
-import { createRaindrop } from "@services/raindrop/raindrop.js";
+import { createRaindrop } from "@services/raindrop";
 import { extractUrlFromText } from "@util/url.js";
 
 import type { AddedToRaindropView } from "./views.js";

--- a/src/commands/addToRaindrop.ts
+++ b/src/commands/addToRaindrop.ts
@@ -5,7 +5,7 @@ import { createRaindrop } from "@services/raindrop/raindrop.js";
 import { extractUrlFromText } from "@util/url.js";
 
 import type { AddedToRaindropView } from "./views.js";
-import type { LogseqServiceClient } from "@services/interfaces.js";
+import type { LogseqServiceClient } from "@services/logseq";
 
 const STRINGS = {
   ERROR: {

--- a/src/commands/commands.ts
+++ b/src/commands/commands.ts
@@ -1,6 +1,6 @@
 import type { Command } from "@commands/Command.js";
 import { genAddUrlsToRaindropCmd } from "@commands/addToRaindrop.js";
-import type { LogseqServiceClient } from "@services/interfaces.js";
+import type { LogseqServiceClient } from "@services/logseq";
 
 const genSlashCommands = (logseqClient: LogseqServiceClient): Command[] => [
   {

--- a/src/components/atoms/ThemeProvider.svelte
+++ b/src/components/atoms/ThemeProvider.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { getContext } from "svelte";
   import { logseqClientCtxKey } from "@services/logseq/client.js";
-  import type { LogseqServiceClient } from "@services/interfaces.js";
+  import type { LogseqServiceClient } from "@services/logseq";
 
   const logseqClient = getContext<LogseqServiceClient>(logseqClientCtxKey);
 

--- a/src/components/atoms/ThemeProvider.svelte
+++ b/src/components/atoms/ThemeProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getContext } from "svelte";
-  import { logseqClientCtxKey } from "@services/logseq/client.js";
+  import { logseqClientCtxKey } from "@services/logseq";
   import type { LogseqServiceClient } from "@services/logseq";
 
   const logseqClient = getContext<LogseqServiceClient>(logseqClientCtxKey);

--- a/src/components/organisms/ImportRaindrops.svelte
+++ b/src/components/organisms/ImportRaindrops.svelte
@@ -2,13 +2,13 @@
   import { getContext, onMount } from "svelte";
   import { writable, derived } from "svelte/store";
 
-  import type {Raindrop as TRaindrop} from "@types";
+  import type { Raindrop as TRaindrop } from "@types";
   import Raindrop from "@atoms/Raindrop.svelte";
   import LoadingSpinner from "@atoms/LoadingSpinner.svelte";
   import { upsertRaindropPage } from "src/upsertRaindropPage.js";
   import { normalizeApiRaindrop } from "@services/raindrop/normalize.js";
   import { match } from "true-myth/result";
-  import type { LogseqServiceClient } from "src/services/interfaces.js";
+  import type { LogseqServiceClient } from "@services/logseq";
   import { logseqClientCtxKey } from "src/services/logseq/client.js";
   import { getRaindrop, searchTerm } from "@services/raindrop/index.js";
 
@@ -26,7 +26,7 @@
     const requestTime = new Date();
     requestsInFlight.update((n) => n + 1);
 
-    const res = await searchTerm(term, '0');
+    const res = await searchTerm(term, "0");
     const { items } = await res.json();
     // do some work
     requestsInFlight.update((n) => n - 1);
@@ -41,18 +41,21 @@
     performSearch((event.target as HTMLInputElement).value);
   };
 
-  const onUpsertRaindropPage = async (id: TRaindrop['id']) => {
+  const onUpsertRaindropPage = async (id: TRaindrop["id"]) => {
     const maybeFullRaindrop = await getRaindrop(id);
-    match({
-      Ok: (fullRaindrop) => upsertRaindropPage(fullRaindrop, logseqClient),
-      Err: () => {
-      logseqClient.displayMessage(
-        "Something went wrong while trying to contact Raindrop",
-        "error"
-      );
-      }
-    }, maybeFullRaindrop)
-  }
+    match(
+      {
+        Ok: (fullRaindrop) => upsertRaindropPage(fullRaindrop, logseqClient),
+        Err: () => {
+          logseqClient.displayMessage(
+            "Something went wrong while trying to contact Raindrop",
+            "error"
+          );
+        },
+      },
+      maybeFullRaindrop
+    );
+  };
 
   onMount(() => {
     performSearch("");

--- a/src/components/organisms/ImportRaindrops.svelte
+++ b/src/components/organisms/ImportRaindrops.svelte
@@ -6,11 +6,14 @@
   import Raindrop from "@atoms/Raindrop.svelte";
   import LoadingSpinner from "@atoms/LoadingSpinner.svelte";
   import { upsertRaindropPage } from "src/upsertRaindropPage.js";
-  import { normalizeApiRaindrop } from "@services/raindrop/normalize.js";
   import { match } from "true-myth/result";
   import type { LogseqServiceClient } from "@services/logseq";
   import { logseqClientCtxKey } from "src/services/logseq/client.js";
-  import { getRaindrop, searchTerm } from "@services/raindrop/index.js";
+  import {
+    getRaindrop,
+    normalizeApiRaindrop,
+    searchTerm,
+  } from "@services/raindrop";
 
   const remoteData = writable<TRaindrop[]>([]);
   const requestsInFlight = writable(0);

--- a/src/components/organisms/SinglePageSyncMenu.svelte
+++ b/src/components/organisms/SinglePageSyncMenu.svelte
@@ -3,7 +3,7 @@
   import { derived, writable } from "svelte/store";
 
   import type { LogseqServiceClient } from "@services/logseq";
-  import { logseqClientCtxKey } from "@services/logseq/client.js";
+  import { logseqClientCtxKey } from "@services/logseq";
 
   import { importHighlightsSinceLastSync } from "src/importHighlights.js";
   import { pluginSettings } from "src/stores/pluginSettings.js";

--- a/src/components/organisms/SinglePageSyncMenu.svelte
+++ b/src/components/organisms/SinglePageSyncMenu.svelte
@@ -2,7 +2,7 @@
   import { getContext } from "svelte";
   import { derived, writable } from "svelte/store";
 
-  import type { LogseqServiceClient } from "@services/interfaces.js";
+  import type { LogseqServiceClient } from "@services/logseq";
   import { logseqClientCtxKey } from "@services/logseq/client.js";
 
   import { importHighlightsSinceLastSync } from "src/importHighlights.js";

--- a/src/importHighlights.spec.ts
+++ b/src/importHighlights.spec.ts
@@ -1,8 +1,10 @@
-import { generateMoqseqClient } from "@services/logseq/mock/client.js";
+import { TESTING_FUNCS } from "@services/logseq";
 import type { Raindrop } from "@types";
 import { assert, describe, expect, it } from "vitest";
 import { generateRaindrop } from "./testing/raindropFactory.js";
 import { importRaindropsFromGenerator } from "./importHighlights.js";
+
+const { generateMoqseqClient } = TESTING_FUNCS;
 
 describe("importRaindropsFromGenerator", () => {
   it("must insert new blocks above old blocks", async () => {

--- a/src/importHighlights.ts
+++ b/src/importHighlights.ts
@@ -4,8 +4,8 @@ import { getOrCreatePageByName } from "@queries/getOrCreatePage.js";
 import type {
   LSBlockEntity,
   LogseqServiceClient,
-} from "@services/interfaces.js";
-import { formatDateForSettings } from "@services/logseq/formatting.js";
+  formatDateForSettings,
+} from "@services/logseq";
 import { createCollectionUpdatedSinceGenerator } from "@services/raindrop/collection.js";
 import type { Raindrop } from "@types";
 import {

--- a/src/importHighlights.ts
+++ b/src/importHighlights.ts
@@ -1,17 +1,14 @@
 import type { IBatchBlock } from "@logseq/libs/dist/LSPlugin.user.js";
 import { getOrCreateBlockInPage } from "@queries/getOrCreateBlockInPage.js";
 import { getOrCreatePageByName } from "@queries/getOrCreatePage.js";
-import type {
-  LSBlockEntity,
-  LogseqServiceClient,
-  formatDateForSettings,
-} from "@services/logseq";
+import type { LSBlockEntity, LogseqServiceClient } from "@services/logseq";
 import { createCollectionUpdatedSinceGenerator } from "@services/raindrop/collection.js";
 import type { Raindrop } from "@types";
 import {
   SETTING_ENUM,
+  formatDateForSettings,
   importFilterOptions,
-} from "@services/logseq/settings.js";
+} from "@services/logseq";
 import type { Result } from "true-myth";
 import { err, ok } from "true-myth/result";
 import { renderBookmark, renderHighlight } from "./bookmarks/rendering.js";

--- a/src/importHighlights.ts
+++ b/src/importHighlights.ts
@@ -2,7 +2,7 @@ import type { IBatchBlock } from "@logseq/libs/dist/LSPlugin.user.js";
 import { getOrCreateBlockInPage } from "@queries/getOrCreateBlockInPage.js";
 import { getOrCreatePageByName } from "@queries/getOrCreatePage.js";
 import type { LSBlockEntity, LogseqServiceClient } from "@services/logseq";
-import { createCollectionUpdatedSinceGenerator } from "@services/raindrop/collection.js";
+import { createCollectionUpdatedSinceGenerator } from "@services/raindrop";
 import type { Raindrop } from "@types";
 import {
   SETTING_ENUM,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import App from "./App.svelte";
 
 import { registerCommands } from "@commands/commands.js";
 import { generateLogseqClient, registerSettings } from "@services/logseq";
-import { setupRaindropHttpClient } from "@services/raindrop/index.js";
+import { setupRaindropHttpClient } from "@services/raindrop";
 
 const main = async () => {
   const addColorStyle = import.meta.env.PROD ? "" : "color: orange!important;";

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,8 @@ import "svelte";
 import App from "./App.svelte";
 
 import { registerCommands } from "@commands/commands.js";
-import { registerSettings } from "@services/logseq/settings.js";
+import { generateLogseqClient, registerSettings } from "@services/logseq";
 import { setupRaindropHttpClient } from "@services/raindrop/index.js";
-import { generateLogseqClient } from "@services/logseq/client.js";
 
 const main = async () => {
   const addColorStyle = import.meta.env.PROD ? "" : "color: orange!important;";

--- a/src/queries/getBlockBy.spec.ts
+++ b/src/queries/getBlockBy.spec.ts
@@ -1,7 +1,7 @@
 import { generateMoqseqClient } from "src/services/logseq/mock/client.js";
 import { describe, expect, it } from "vitest";
 import { findPagesByRaindropID } from "./getBlockBy.js";
-import type { LSBlockEntity, LSPageEntity } from "src/services/interfaces.js";
+import type { LSBlockEntity, LSPageEntity } from "@services/logseq";
 
 // Created by running the query "(property raindrop-id 457389317)" on
 // my Logseq database, and then removing the following non-supported fields:

--- a/src/queries/getBlockBy.ts
+++ b/src/queries/getBlockBy.ts
@@ -5,7 +5,7 @@ import type {
   LSBlockEntity,
   LSPageEntity,
   LogseqServiceClient,
-} from "src/services/interfaces.js";
+} from "@services/logseq";
 
 const findPagesByProperty =
   (

--- a/src/queries/getOrCreateBlockInPage.ts
+++ b/src/queries/getOrCreateBlockInPage.ts
@@ -1,7 +1,4 @@
-import type {
-  LSBlockEntity,
-  LogseqServiceClient,
-} from "@services/interfaces.js";
+import type { LSBlockEntity, LogseqServiceClient } from "@services/logseq";
 import type { Result } from "true-myth";
 import { ok, err } from "true-myth/result";
 

--- a/src/queries/getOrCreatePage.ts
+++ b/src/queries/getOrCreatePage.ts
@@ -1,10 +1,7 @@
 import type { Result } from "true-myth";
 import { err, ok } from "true-myth/result";
 
-import type {
-  LSPageEntity,
-  LogseqServiceClient,
-} from "@services/interfaces.js";
+import type { LSPageEntity, LogseqServiceClient } from "@services/logseq";
 
 export const getOrCreatePageByName = async (
   logseqClient: LogseqServiceClient,

--- a/src/services/logseq/client.ts
+++ b/src/services/logseq/client.ts
@@ -5,7 +5,7 @@ import { applyAsyncFunc } from "@util/async.js";
 import type {
   LSEventMap,
   LogseqServiceClient as LogseqServiceWrapper,
-} from "../interfaces.js";
+} from "./interfaces.js";
 import { generateClientSettings } from "./settings.js";
 
 export const logseqClientCtxKey = Symbol();

--- a/src/services/logseq/client.ts
+++ b/src/services/logseq/client.ts
@@ -1,9 +1,11 @@
 import type { ILSPluginUser } from "@logseq/libs/dist/LSPlugin.user.js";
+
+import { applyAsyncFunc } from "@util/async.js";
+
 import type {
   LSEventMap,
   LogseqServiceClient as LogseqServiceWrapper,
 } from "../interfaces.js";
-import { applyAsyncFunc } from "@util/async.js";
 import { generateClientSettings } from "./settings.js";
 
 export const logseqClientCtxKey = Symbol();

--- a/src/services/logseq/emptyState.ts
+++ b/src/services/logseq/emptyState.ts
@@ -1,4 +1,4 @@
-import type { LSBlockEntity, LogseqServiceClient } from "../interfaces.js";
+import type { LSBlockEntity, LogseqServiceClient } from "./interfaces.js";
 
 import {
   filterBlocksWithProperty,

--- a/src/services/logseq/index.ts
+++ b/src/services/logseq/index.ts
@@ -4,9 +4,17 @@ export type {
   LogseqServiceClient,
 } from "./interfaces.js";
 
-export { formatDateForSettings } from "./formatting.js";
+export {
+  formatDateForSettings,
+  formatDateUserPreference,
+} from "./formatting.js";
 export { ioAddEmptyStateBlock, ioRemoveEmptyStateBlock } from "./emptyState.js";
-export { generateLogseqClient } from "./client.js";
+export { generateLogseqClient, logseqClientCtxKey } from "./client.js";
+export {
+  SETTING_ENUM,
+  importFilterOptions,
+  registerSettings,
+} from "./settings.js";
 
 // Used for testing
 import type { PageEntityWithRootBlocks } from "./mock/types.js";

--- a/src/services/logseq/index.ts
+++ b/src/services/logseq/index.ts
@@ -1,0 +1,21 @@
+export { generateLogseqClient } from "./client.js";
+
+export type {
+  LSBlockEntity,
+  LSPageEntity,
+  LogseqServiceClient,
+} from "./interfaces.js";
+export { formatDateForSettings } from "./formatting.js";
+
+export { ioAddEmptyStateBlock, ioRemoveEmptyStateBlock } from "./emptyState.js";
+
+// Used for testing
+import type { PageEntityWithRootBlocks } from "./mock/types.js";
+import { generateMoqseqClient } from "./mock/client.js";
+
+export const TESTING_FUNCS = {
+  generateMoqseqClient,
+};
+export type TESTING_TYPES = {
+  PageEntityWithRootBlocks: PageEntityWithRootBlocks;
+};

--- a/src/services/logseq/index.ts
+++ b/src/services/logseq/index.ts
@@ -1,21 +1,20 @@
-export { generateLogseqClient } from "./client.js";
-
 export type {
   LSBlockEntity,
   LSPageEntity,
   LogseqServiceClient,
 } from "./interfaces.js";
-export { formatDateForSettings } from "./formatting.js";
 
+export { formatDateForSettings } from "./formatting.js";
 export { ioAddEmptyStateBlock, ioRemoveEmptyStateBlock } from "./emptyState.js";
+export { generateLogseqClient } from "./client.js";
 
 // Used for testing
 import type { PageEntityWithRootBlocks } from "./mock/types.js";
 import { generateMoqseqClient } from "./mock/client.js";
 
-export const TESTING_FUNCS = {
-  generateMoqseqClient,
-};
 export type TESTING_TYPES = {
   PageEntityWithRootBlocks: PageEntityWithRootBlocks;
+};
+export const TESTING_FUNCS = {
+  generateMoqseqClient,
 };

--- a/src/services/logseq/interfaces.ts
+++ b/src/services/logseq/interfaces.ts
@@ -9,7 +9,7 @@ import type {
   PageEntity,
   SettingSchemaDesc,
 } from "@logseq/libs/dist/LSPlugin.js";
-import type { PluginSettings, SETTING_ID } from "./logseq/settings.js";
+import type { PluginSettings, SETTING_ID } from "./settings.js";
 
 // Duplicated from @logseq/libs/dist/LSPlugin.d.ts because the Logseq type
 // includes a `[key: string]: any]` prop which corrupts the rest of the type

--- a/src/services/logseq/mock/client.spec.ts
+++ b/src/services/logseq/mock/client.spec.ts
@@ -1,7 +1,7 @@
 import type { IEntityID } from "@logseq/libs/dist/LSPlugin.js";
 import { assert, describe, expect, it, vitest } from "vitest";
 import { generateMoqseqClient, recursiveChildrenOfBlock } from "./client.js";
-import type { LSBlockEntity } from "../../interfaces.js";
+import type { LSBlockEntity } from "../interfaces.js";
 import { randomUUID } from "crypto";
 
 describe("recursiveChildrenOfBlock", () => {

--- a/src/services/logseq/mock/client.ts
+++ b/src/services/logseq/mock/client.ts
@@ -5,7 +5,7 @@ import type {
   LSBlockEntity,
   LSEvent,
   LSEventMap,
-} from "../../interfaces.js";
+} from "../interfaces.js";
 import { applyAsyncFunc } from "@util/async.js";
 import type {
   AppUserConfigs,

--- a/src/services/logseq/mock/leftAndParent.ts
+++ b/src/services/logseq/mock/leftAndParent.ts
@@ -10,7 +10,7 @@ import type {
 } from "@logseq/libs/dist/LSPlugin.js";
 
 import type { BlockMap, PageMap } from "./types.js";
-import type { LSBlockEntity } from "@services/interfaces.js";
+import type { LSBlockEntity } from "../interfaces.js";
 
 const getLeftmostChild = (
   children: (BlockEntity | BlockUUIDTuple)[],

--- a/src/services/logseq/mock/types.ts
+++ b/src/services/logseq/mock/types.ts
@@ -1,5 +1,5 @@
 import type { BlockUUID } from "@logseq/libs/dist/LSPlugin.js";
-import type { LSBlockEntity, LSPageEntity } from "@services/interfaces.js";
+import type { LSBlockEntity, LSPageEntity } from "../interfaces.js";
 
 export type PageEntityWithRootBlocks = LSPageEntity & {
   roots?: ["uuid", BlockUUID][];

--- a/src/services/raindrop/collection.spec.ts
+++ b/src/services/raindrop/collection.spec.ts
@@ -8,7 +8,7 @@ vi.mock("./http.js", () => {
   const get = vi.fn();
   const post = vi.fn();
 
-  return { httpClient: { get, post } };
+  return { httpClient: { get, post }, setupHttpClient: () => {} };
 });
 
 /**

--- a/src/services/raindrop/collection.ts
+++ b/src/services/raindrop/collection.ts
@@ -2,7 +2,7 @@ import { httpClient } from "./http.js";
 import {
   normalizeApiRaindrop,
   type RaindropResponse,
-} from "@services/raindrop/normalize.js";
+} from "@services/raindrop";
 
 type CollectionResponse = {
   result: boolean;

--- a/src/services/raindrop/index.ts
+++ b/src/services/raindrop/index.ts
@@ -1,5 +1,7 @@
 import { setupHttpClient } from "./http.js";
 
+export { normalizeApiRaindrop, type RaindropResponse } from "./normalize.js";
+
 export * from "./raindrop.js";
 export * from "./collection.js";
 

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -1,4 +1,4 @@
-import type { LogseqServiceClient } from "@services/interfaces.js";
+import type { LogseqServiceClient } from "@services/logseq";
 
 import { importHighlightsSinceLastSync } from "./importHighlights.js";
 

--- a/src/testing/raindropFactory.ts
+++ b/src/testing/raindropFactory.ts
@@ -1,5 +1,5 @@
 import type { Annotation, Raindrop } from "@types";
-import type { RaindropResponse } from "@services/raindrop/normalize.js";
+import type { RaindropResponse } from "@services/raindrop";
 import { randomUUID } from "crypto";
 
 const generateAnnotation = (opts?: Partial<Annotation>): Annotation => ({

--- a/src/upsertRaindropPage.spec.ts
+++ b/src/upsertRaindropPage.spec.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect, assert } from "vitest";
 
-import type { LSBlockEntity, LSPageEntity } from "@services/interfaces.js";
+import type { LSBlockEntity, LSPageEntity } from "@services/logseq";
 import type { Annotation, Raindrop } from "@types";
-import type { PageEntityWithRootBlocks } from "@services/logseq/mock/types.js";
-import { generateMoqseqClient } from "@services/logseq/mock/client.js";
+
+import { TESTING_FUNCS } from "@services/logseq";
+import type { TESTING_TYPES } from "@services/logseq";
+
+type PageEntityWithRootBlocks = TESTING_TYPES["PageEntityWithRootBlocks"];
+const { generateMoqseqClient } = TESTING_FUNCS;
 
 import { __TESTING } from "./upsertRaindropPage.js";
 

--- a/src/upsertRaindropPage.ts
+++ b/src/upsertRaindropPage.ts
@@ -6,16 +6,16 @@ import type {
   LSBlockEntity,
   LSPageEntity,
   LogseqServiceClient,
-} from "src/services/interfaces.js";
+} from "@services/logseq";
+import {
+  ioAddEmptyStateBlock,
+  ioRemoveEmptyStateBlock,
+} from "@services/logseq";
 import { findPagesByRaindropID } from "src/queries/getBlockBy.js";
 import { formatRaindropToProperties } from "@util/pageFormatter.js";
 import { applyAsyncFunc } from "@util/async.js";
 
 import { generatePageName } from "./util/generatePageName.js";
-import {
-  ioAddEmptyStateBlock,
-  ioRemoveEmptyStateBlock,
-} from "@services/logseq/emptyState.js";
 
 const alertDuplicatePageIdUsed = (r: Raindrop, client: LogseqServiceClient) => {
   client.displayMessage(

--- a/src/util/blocks.spec.ts
+++ b/src/util/blocks.spec.ts
@@ -1,4 +1,4 @@
-import type { LSBlockEntity } from "src/services/interfaces.js";
+import type { LSBlockEntity } from "@services/logseq";
 import { describe, expect, it } from "vitest";
 import {
   blockHasProperty,

--- a/src/util/blocks.ts
+++ b/src/util/blocks.ts
@@ -1,4 +1,4 @@
-import type { LSBlockEntity } from "src/services/interfaces.js";
+import type { LSBlockEntity } from "@services/logseq";
 
 import { applyAsyncFunc } from "@util/async.js";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "@commands/*": ["src/commands/*"],
       "@organisms/*": ["src/components/organisms/*"],
       "@queries/*": ["src/queries/*"],
-      "@services/*": ["src/services/*"],
+      "@services/logseq": ["src/services/logseq/index.ts"],
+      "@services/raindrop/*": ["src/services/raindrop/*"],
       "@util/*": ["src/util/*"]
     },
     // The Svelte config uses some deprecated features.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,7 +24,7 @@
       "@organisms/*": ["src/components/organisms/*"],
       "@queries/*": ["src/queries/*"],
       "@services/logseq": ["src/services/logseq/index.ts"],
-      "@services/raindrop/*": ["src/services/raindrop/*"],
+      "@services/raindrop": ["src/services/raindrop/index.ts"],
       "@util/*": ["src/util/*"]
     },
     // The Svelte config uses some deprecated features.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
       "@organisms": resolve("src/components/organisms"),
       "@queries": resolve("src/queries"),
       "@services/logseq": resolve("src/services/logseq"),
-      "@services": resolve("src/services"),
+      "@services/raindrop": resolve("src/services/raindrop"),
       "@util": resolve("src/util"),
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "@commands": resolve("src/commands"),
       "@organisms": resolve("src/components/organisms"),
       "@queries": resolve("src/queries"),
+      "@services/logseq": resolve("src/services/logseq"),
       "@services": resolve("src/services"),
       "@util": resolve("src/util"),
     },


### PR DESCRIPTION
Part of a process on making our Logseq client a _deep module_. Everything outside of the service should not know or care how it's implemented.

That starts with creating an interface, `index.ts`, for both services.